### PR TITLE
style: gap between the chatbox & chatlog

### DIFF
--- a/src/components/chat/mainContent.css
+++ b/src/components/chat/mainContent.css
@@ -43,7 +43,7 @@
   flex: 1;
   overflow-y: auto;
   padding: 20px;
-  padding-bottom: 0;
+  padding-bottom: 1.5em;
 }
 
 .scroller::-webkit-scrollbar {
@@ -125,7 +125,6 @@
   padding: 0 16px 24px;
   background-color: #1f2335;
   flex-shrink: 0;
-  margin-top: 10px;
 }
 
 input:focus {


### PR DESCRIPTION
adds a gap between the chatbox and chatlog, making the chatlog feel less cramped, reducing focal confusion, and providing some indication when the user has fully scrolled to the bottom of the channel